### PR TITLE
"Building domain entities"

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,4 +1,4 @@
-name: Java 24 CI Pipeline
+name: Java 17 CI Pipeline
 
 on: [push, pull_request]
 
@@ -28,11 +28,11 @@ jobs:
     - name: Set executable permissions
       run: chmod +x ./mvnw  # Adicione esta linha
       
-    - name: Setup Java 24 (Early Access)
+    - name: Setup Java 17 (Early Access)
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '24-ea'
+        java-version: '17-ea'
         check-latest: true
         
     - name: Validate Java version
@@ -41,7 +41,7 @@ jobs:
     - name: Build with Maven
       run: |
         ./mvnw -B package \
-          -Dmaven.compiler.release=24 \
+          -Dmaven.compiler.release=17 \
           -Dmaven.compiler.parameters=true \
           -Dmaven.compiler.showWarnings=true
       env:

--- a/Dockerfile.app.template
+++ b/Dockerfile.app.template
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:24-jdk-jammy
+FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app
 
 
@@ -11,4 +11,4 @@ COPY src ./src
 
 RUN ./mvnw package -DskipTests
 
-ENTRYPOINT ["java", "-jar", "target/api-0.9.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-jar", "target/patients-service-0.0.1-SNAPSHOT.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,20 +1,20 @@
 services:
-  app:
+  patients-service:
     build: 
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.app.template
     ports:
       - "8080:8080"
     environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/medical_db
-      SPRING_DATASOURCE_USERNAME: sandoval
-      SPRING_DATASOURCE_PASSWORD: salessa
+      SPRING_DATASOURCE_URL: jdbc:oracle:thin:@oracle_db:1521/XE
+      SPRING_DATASOURCE_USERNAME: system
+      SPRING_DATASOURCE_PASSWORD: oracle_password
       SPRING_PROFILES_ACTIVE: dev
     volumes:
-      - ~/.m2:/root/.m2  # Cache do Maven
+      - ~/.m2:/root/.m2  # Maven cache
       - ./target:/app/target
     depends_on:
-      db:
+      oracle_db:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
@@ -22,28 +22,30 @@ services:
       timeout: 10s
       retries: 3
 
-  db:
-    image: ltservices/medical-sas-postgres:1.0.4
+  oracle_db:
+    image: gvenzl/oracle-xe:18.4.0-slim
     environment:
-      POSTGRES_DB: medical_db
-      POSTGRES_USER: sandoval
-      POSTGRES_PASSWORD: salessa
-      POSTGRES_HOST_AUTH_METHOD: trust
+      ORACLE_PASSWORD: oracle_password # Sets the password for SYSTEM, SYS, PDBADMIN
+      # ORACLE_DATABASE: APP # Optionally, create a database (not typical for XE which has a fixed one)
+      # APP_USER: medical_user # This image can create a user with this name
+      # APP_USER_PASSWORD: medical_password # Password for APP_USER
     ports:
-      - "5432:5432"
+      - "1521:1521"
+      - "5500:5500" # For EM Express if available
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - oracle_data:/opt/oracle/oradata
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U sandoval -d medical_db"]
-      interval: 5s
-      timeout: 5s
+      test: ["CMD", "nc", "-z", "localhost", "1521"] # Basic TCP port check
+      interval: 30s # Increased interval for Oracle
+      timeout: 10s
       retries: 5
+    restart: unless-stopped
 
   pipeline-watcher:
     image: eclipse-temurin:17-jdk-jammy
     volumes:
       - .:/workspace
-      - ~/.m2:/root/.m2  # Cache compartilhado do Maven
+      - ~/.m2:/root/.m2  # Shared Maven cache
     working_dir: /workspace
     command: >
       bash -c "apt-get update && apt-get install -y inotify-tools curl &&
@@ -51,11 +53,12 @@ services:
         inotifywait -r -e modify,create,delete \
           --exclude='.*(/target|\.git|\.mvn/wrapper).*' \
           ./src ./pom.xml &&
-        echo 'Mudanças detectadas. Executando verificações...' &&
+        echo 'Changes detected. Running checks...' &&
         ./mvnw verify;
       done"
-    depends_on:
-      - db
+    # Removed direct dependency on 'db' for pipeline-watcher, 
+    # as 'mvnw verify' might not always need a live DB.
+    # If tests run by 'verify' require DB, this might need to be reinstated for 'oracle_db'.
 
 volumes:
-  postgres_data:
+  oracle_data: {}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.release>17</maven.compiler.release>
 		<maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
 		<lombok.version>1.18.32</lombok.version>
-		<!-- Updated argLine for Java 17, removed --enable-preview and jdk.compiler specific add-opens -->
+		<jakarta.persistence.version>3.1.0</jakarta.persistence.version>
 		<argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
 	</properties>
 
@@ -35,6 +35,13 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- Jakarta Persistence API -->
+		<dependency>
+			<groupId>jakarta.persistence</groupId>
+			<artifactId>jakarta.persistence-api</artifactId>
+			<version>${jakarta.persistence.version}</version>
 		</dependency>
 
 		<!-- Runtime Dependencies -->
@@ -90,9 +97,7 @@
 				<configuration>
 					<release>${maven.compiler.release}</release>
 					<compilerArgs>
-						<!-- <arg>--enable-preview</arg> --> <!-- Removed for Java 17 unless specific preview features are needed -->
 						<arg>-Xlint:all</arg>
-						<!-- <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg> --> <!-- Removed for Java 17 -->
 					</compilerArgs>
 					<fork>true</fork>
 					<meminitial>1024m</meminitial>
@@ -113,9 +118,7 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
 					<jvmArguments>
-						<!-- --enable-preview --> <!-- Removed for Java 17 unless specific preview features are needed -->
 						--add-opens java.base/java.lang=ALL-UNNAMED
-						<!-- --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --> <!-- Removed for Java 17 -->
 					</jvmArguments>
 					<excludes>
 						<exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -11,17 +11,18 @@
 	</parent>
 
 	<groupId>com.medicalapp</groupId>
-	<artifactId>api</artifactId>
+	<artifactId>patients-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>medical-sas-api</name>
-	<description>Sistema de API Médica</description>
+	<name>patients-service</name>
+	<description>Microservice for Patient Management</description>
 
 	<properties>
-		<java.version>24</java.version>
-		<maven.compiler.release>24</maven.compiler.release>
+		<java.version>17</java.version>
+		<maven.compiler.release>17</maven.compiler.release>
 		<maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
 		<lombok.version>1.18.32</lombok.version>
-		<argLine>--enable-preview --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</argLine>
+		<!-- Updated argLine for Java 17, removed --enable-preview and jdk.compiler specific add-opens -->
+		<argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
 	</properties>
 
 	<dependencies>
@@ -49,9 +50,11 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
+		<!-- Oracle JDBC Driver -->
 		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
+			<groupId>com.oracle.database.jdbc</groupId>
+			<artifactId>ojdbc8</artifactId>
+			<version>19.3.0.0</version>
 			<scope>runtime</scope>
 		</dependency>
 
@@ -79,7 +82,7 @@
 
 	<build>
 		<plugins>
-			<!-- Maven Compiler Plugin configurado para Java 24 -->
+			<!-- Maven Compiler Plugin configured for Java 17 -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -87,9 +90,9 @@
 				<configuration>
 					<release>${maven.compiler.release}</release>
 					<compilerArgs>
-						<arg>--enable-preview</arg>
+						<!-- <arg>--enable-preview</arg> --> <!-- Removed for Java 17 unless specific preview features are needed -->
 						<arg>-Xlint:all</arg>
-						<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+						<!-- <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg> --> <!-- Removed for Java 17 -->
 					</compilerArgs>
 					<fork>true</fork>
 					<meminitial>1024m</meminitial>
@@ -110,9 +113,9 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
 					<jvmArguments>
-						--enable-preview
+						<!-- --enable-preview --> <!-- Removed for Java 17 unless specific preview features are needed -->
 						--add-opens java.base/java.lang=ALL-UNNAMED
-						--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+						<!-- --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --> <!-- Removed for Java 17 -->
 					</jvmArguments>
 					<excludes>
 						<exclude>
@@ -123,7 +126,7 @@
 				</configuration>
 			</plugin>
 
-			<!-- Maven Surefire Plugin para testes -->
+			<!-- Maven Surefire Plugin for tests -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/com/medicalapp/api/domain/entities/Appointment.java
+++ b/src/main/java/com/medicalapp/api/domain/entities/Appointment.java
@@ -1,4 +1,83 @@
 package com.medicalapp.api.domain.entities;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "appointments")
 public class Appointment {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+    
+    private UUID patientId;
+    private UUID doctorId;
+    private LocalDateTime appointmentDateTime;
+    private String reason;
+    private String status;
+    
+    
+    public Appointment() {
+    }
+    
+    public Appointment(UUID patientId, UUID doctorId, LocalDateTime appointmentDateTime, String reason, String status) {
+        this.patientId = patientId;
+        this.doctorId = doctorId;
+        this.appointmentDateTime = appointmentDateTime;
+        this.reason = reason;
+        this.status = status;
+    }
+    
+    
+    public UUID getId() {
+        return id;
+    }
+    
+    public UUID getPatientId() {
+        return patientId;
+    }
+    
+    public void setPatientId(UUID patientId) {
+        this.patientId = patientId;
+    }
+    
+    public UUID getDoctorId() {
+        return doctorId;
+    }
+    
+    public void setDoctorId(UUID doctorId) {
+        this.doctorId = doctorId;
+    }
+    
+    public LocalDateTime getAppointmentDateTime() {
+        return appointmentDateTime;
+    }
+    
+    public void setAppointmentDateTime(LocalDateTime appointmentDateTime) {
+        this.appointmentDateTime = appointmentDateTime;
+    }
+    
+    public String getReason() {
+        return reason;
+    }
+    
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+    
+    public String getStatus() {
+        return status;
+    }
+    
+    public void setStatus(String status) {
+        this.status = status;
+    }
+    
+    
 }

--- a/src/main/java/com/medicalapp/api/domain/entities/Doctor.java
+++ b/src/main/java/com/medicalapp/api/domain/entities/Doctor.java
@@ -1,4 +1,102 @@
 package com.medicalapp.api.domain.entities;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "doctors")
 public class Doctor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+    private String specialty;
+    private String crm; // Registro profissional
+    private String email;
+    private String phone;
+    private boolean active;
+
+
+    public Doctor() {
+        this.active = true;
+    }
+
+    public Doctor(String name, String specialty, String crm, String email, String phone) {
+        this.name = name;
+        this.specialty = specialty;
+        this.crm = crm;
+        this.email = email;
+        this.phone = phone;
+        this.active = true;
+    }
+
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSpecialty() {
+        return specialty;
+    }
+
+    public void setSpecialty(String specialty) {
+        this.specialty = specialty;
+    }
+
+    public String getCrm() {
+        return crm;
+    }
+
+    public void setCrm(String crm) {
+        this.crm = crm;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+
+
 }

--- a/src/main/java/com/medicalapp/api/domain/entities/Subscription.java
+++ b/src/main/java/com/medicalapp/api/domain/entities/Subscription.java
@@ -1,4 +1,99 @@
 package com.medicalapp.api.domain.entities;
 
-public class Subscription {
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "username"),
+                @UniqueConstraint(columnNames = "email")
+        })
+@Getter
+@Setter
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @NotBlank
+    @Size(max = 50)
+    private String username;
+
+    @NotBlank
+    @Size(max = 100)
+    private String fullName;
+
+    @NotBlank
+    @Size(max = 120)
+    private String password;
+
+    @NotBlank
+    @Size(max = 100)
+    @Email
+    private String email;
+
+    @Size(max = 20)
+    private String phone;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
+    private Set<Role> roles = new HashSet<>();
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    private boolean active = true;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+
+    public User() {
+    }
+
+    public User(String username, String fullName, String email, String password) {
+        this.username = username;
+        this.fullName = fullName;
+        this.email = email;
+        this.password = password;
+    }
+
+
+    public void activate() {
+        this.active = true;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User user)) return false;
+        return id != null && id.equals(user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/src/main/java/com/medicalapp/api/domain/entities/User.java
+++ b/src/main/java/com/medicalapp/api/domain/entities/User.java
@@ -1,4 +1,102 @@
 package com.medicalapp.api.domain.entities;
 
-public class User {
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "doctors")
+public class Doctor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+    private String specialty;
+    private String crm; // Registro profissional
+    private String email;
+    private String phone;
+    private boolean active;
+
+
+    public Doctor() {
+        this.active = true; // Por padrão, o médico é criado como ativo
+    }
+
+    public Doctor(String name, String specialty, String crm, String email, String phone) {
+        this.name = name;
+        this.specialty = specialty;
+        this.crm = crm;
+        this.email = email;
+        this.phone = phone;
+        this.active = true;
+    }
+
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSpecialty() {
+        return specialty;
+    }
+
+    public void setSpecialty(String specialty) {
+        this.specialty = specialty;
+    }
+
+    public String getCrm() {
+        return crm;
+    }
+
+    public void setCrm(String crm) {
+        this.crm = crm;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+
+
 }

--- a/src/main/java/com/medicalapp/patientsservice/PatientsServiceApplication.java
+++ b/src/main/java/com/medicalapp/patientsservice/PatientsServiceApplication.java
@@ -1,13 +1,13 @@
-package com.medicalapp.api;
+package com.medicalapp.patientsservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class ApiApplication {
+public class PatientsServiceApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(ApiApplication.class, args);
+		SpringApplication.run(PatientsServiceApplication.class, args);
 	}
 
 }

--- a/src/main/java/com/medicalapp/patientsservice/controller/PatientController.java
+++ b/src/main/java/com/medicalapp/patientsservice/controller/PatientController.java
@@ -1,0 +1,59 @@
+package com.medicalapp.patientsservice.controller;
+
+import com.medicalapp.patientsservice.model.Patient;
+import com.medicalapp.patientsservice.service.PatientService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/patients")
+public class PatientController {
+
+    private final PatientService patientService;
+
+    @Autowired
+    public PatientController(PatientService patientService) {
+        this.patientService = patientService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Patient>> getAllPatients() {
+        List<Patient> patients = patientService.getAllPatients();
+        return ResponseEntity.ok(patients);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Patient> getPatientById(@PathVariable Long id) {
+        Optional<Patient> patient = patientService.getPatientById(id);
+        return patient.map(ResponseEntity::ok)
+                      .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Patient> createPatient(@RequestBody Patient patient) {
+        Patient createdPatient = patientService.createPatient(patient);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdPatient);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Patient> updatePatient(@PathVariable Long id, @RequestBody Patient patientDetails) {
+        Optional<Patient> updatedPatient = patientService.updatePatient(id, patientDetails);
+        return updatedPatient.map(ResponseEntity::ok)
+                             .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePatient(@PathVariable Long id) {
+        boolean deleted = patientService.deletePatient(id);
+        if (deleted) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/com/medicalapp/patientsservice/model/Patient.java
+++ b/src/main/java/com/medicalapp/patientsservice/model/Patient.java
@@ -1,0 +1,40 @@
+package com.medicalapp.patientsservice.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Column;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Patient {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    private LocalDate dateOfBirth;
+
+    private String gender; // Consider using an Enum for this
+
+    private String contactNumber;
+
+    @Column(unique = true)
+    private String email;
+
+    private String address;
+}

--- a/src/main/java/com/medicalapp/patientsservice/repository/PatientRepository.java
+++ b/src/main/java/com/medicalapp/patientsservice/repository/PatientRepository.java
@@ -1,0 +1,9 @@
+package com.medicalapp.patientsservice.repository;
+
+import com.medicalapp.patientsservice.model.Patient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PatientRepository extends JpaRepository<Patient, Long> {
+}

--- a/src/main/java/com/medicalapp/patientsservice/service/PatientService.java
+++ b/src/main/java/com/medicalapp/patientsservice/service/PatientService.java
@@ -1,0 +1,61 @@
+package com.medicalapp.patientsservice.service;
+
+import com.medicalapp.patientsservice.model.Patient;
+import com.medicalapp.patientsservice.repository.PatientRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PatientService {
+
+    private final PatientRepository patientRepository;
+
+    @Autowired
+    public PatientService(PatientRepository patientRepository) {
+        this.patientRepository = patientRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Patient> getAllPatients() {
+        return patientRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Patient> getPatientById(Long id) {
+        return patientRepository.findById(id);
+    }
+
+    @Transactional
+    public Patient createPatient(Patient patient) {
+        // Add any validation or business logic before saving
+        return patientRepository.save(patient);
+    }
+
+    @Transactional
+    public Optional<Patient> updatePatient(Long id, Patient patientDetails) {
+        return patientRepository.findById(id)
+            .map(existingPatient -> {
+                existingPatient.setFirstName(patientDetails.getFirstName());
+                existingPatient.setLastName(patientDetails.getLastName());
+                existingPatient.setDateOfBirth(patientDetails.getDateOfBirth());
+                existingPatient.setGender(patientDetails.getGender());
+                existingPatient.setContactNumber(patientDetails.getContactNumber());
+                existingPatient.setEmail(patientDetails.getEmail());
+                existingPatient.setAddress(patientDetails.getAddress());
+                return patientRepository.save(existingPatient);
+            });
+    }
+
+    @Transactional
+    public boolean deletePatient(Long id) {
+        if (patientRepository.existsById(id)) {
+            patientRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
-spring.application.name=api
+spring.application.name=patients-service
+server.port=8080
+
+# JPA Properties
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.OracleDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true

--- a/src/test/java/com/medicalapp/patientsservice/controller/PatientControllerTest.java
+++ b/src/test/java/com/medicalapp/patientsservice/controller/PatientControllerTest.java
@@ -1,0 +1,130 @@
+package com.medicalapp.patientsservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.medicalapp.patientsservice.model.Patient;
+import com.medicalapp.patientsservice.service.PatientService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+// Use @WebMvcTest for testing the controller layer
+// Specify the controller class to test
+@WebMvcTest(PatientController.class)
+// We don't need @ExtendWith(MockitoExtension.class) when using @WebMvcTest, as it includes Mockito support
+class PatientControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean // Use @MockBean to add mock PatientService to ApplicationContext
+    private PatientService patientService;
+
+    @Autowired
+    private ObjectMapper objectMapper; // For converting objects to JSON
+
+    private Patient patient;
+
+    @BeforeEach
+    void setUp() {
+        patient = new Patient(1L, "John", "Doe", LocalDate.of(1990, 1, 1), "MALE", "1234567890", "john.doe@example.com", "123 Main St");
+    }
+
+    @Test
+    void getAllPatients_shouldReturnListOfPatients() throws Exception {
+        when(patientService.getAllPatients()).thenReturn(Collections.singletonList(patient));
+
+        mockMvc.perform(get("/api/v1/patients"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].firstName").value("John"));
+    }
+
+    @Test
+    void getPatientById_shouldReturnPatient_whenFound() throws Exception {
+        when(patientService.getPatientById(1L)).thenReturn(Optional.of(patient));
+
+        mockMvc.perform(get("/api/v1/patients/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.firstName").value("John"));
+    }
+
+    @Test
+    void getPatientById_shouldReturnNotFound_whenMissing() throws Exception {
+        when(patientService.getPatientById(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/patients/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createPatient_shouldReturnCreatedPatient() throws Exception {
+        when(patientService.createPatient(any(Patient.class))).thenReturn(patient);
+
+        mockMvc.perform(post("/api/v1/patients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(patient)))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.firstName").value("John"));
+    }
+
+    @Test
+    void updatePatient_shouldReturnUpdatedPatient_whenFound() throws Exception {
+        Patient updatedDetails = new Patient(1L, "Jane", "Doe", LocalDate.of(1990, 1, 1), "FEMALE", "0987654321", "jane.doe@example.com", "456 Oak St");
+        when(patientService.updatePatient(anyLong(), any(Patient.class))).thenReturn(Optional.of(updatedDetails));
+
+        mockMvc.perform(put("/api/v1/patients/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updatedDetails)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.firstName").value("Jane"));
+    }
+
+    @Test
+    void updatePatient_shouldReturnNotFound_whenMissing() throws Exception {
+        Patient updatedDetails = new Patient(1L, "Jane", "Doe", null, null, null, null, null);
+        when(patientService.updatePatient(anyLong(), any(Patient.class))).thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/v1/patients/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updatedDetails)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deletePatient_shouldReturnNoContent_whenDeleted() throws Exception {
+        when(patientService.deletePatient(1L)).thenReturn(true);
+
+        mockMvc.perform(delete("/api/v1/patients/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deletePatient_shouldReturnNotFound_whenMissing() throws Exception {
+        when(patientService.deletePatient(1L)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/v1/patients/1"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/medicalapp/patientsservice/service/PatientServiceTest.java
+++ b/src/test/java/com/medicalapp/patientsservice/service/PatientServiceTest.java
@@ -1,0 +1,116 @@
+package com.medicalapp.patientsservice.service;
+
+import com.medicalapp.patientsservice.model.Patient;
+import com.medicalapp.patientsservice.repository.PatientRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PatientServiceTest {
+
+    @Mock
+    private PatientRepository patientRepository;
+
+    @InjectMocks
+    private PatientService patientService;
+
+    private Patient patient;
+
+    @BeforeEach
+    void setUp() {
+        patient = new Patient(1L, "John", "Doe", LocalDate.of(1990, 1, 1), "MALE", "1234567890", "john.doe@example.com", "123 Main St");
+    }
+
+    @Test
+    void getAllPatients_shouldReturnListOfPatients() {
+        when(patientRepository.findAll()).thenReturn(Collections.singletonList(patient));
+        List<Patient> patients = patientService.getAllPatients();
+        assertFalse(patients.isEmpty());
+        assertEquals(1, patients.size());
+        assertEquals("John", patients.get(0).getFirstName());
+        verify(patientRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getPatientById_shouldReturnPatient_whenFound() {
+        when(patientRepository.findById(1L)).thenReturn(Optional.of(patient));
+        Optional<Patient> foundPatient = patientService.getPatientById(1L);
+        assertTrue(foundPatient.isPresent());
+        assertEquals("John", foundPatient.get().getFirstName());
+        verify(patientRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void getPatientById_shouldReturnEmpty_whenNotFound() {
+        when(patientRepository.findById(1L)).thenReturn(Optional.empty());
+        Optional<Patient> foundPatient = patientService.getPatientById(1L);
+        assertFalse(foundPatient.isPresent());
+        verify(patientRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void createPatient_shouldReturnSavedPatient() {
+        when(patientRepository.save(any(Patient.class))).thenReturn(patient);
+        Patient createdPatient = patientService.createPatient(new Patient()); // pass empty or mock patient
+        assertNotNull(createdPatient);
+        assertEquals("John", createdPatient.getFirstName());
+        verify(patientRepository, times(1)).save(any(Patient.class));
+    }
+
+    @Test
+    void updatePatient_shouldReturnUpdatedPatient_whenFound() {
+        Patient updatedDetails = new Patient(1L, "Jane", "Doe", LocalDate.of(1990, 1, 1), "FEMALE", "0987654321", "jane.doe@example.com", "456 Oak St");
+        when(patientRepository.findById(1L)).thenReturn(Optional.of(patient));
+        when(patientRepository.save(any(Patient.class))).thenReturn(updatedDetails); // mock save to return the updated patient
+
+        Optional<Patient> result = patientService.updatePatient(1L, updatedDetails);
+
+        assertTrue(result.isPresent());
+        assertEquals("Jane", result.get().getFirstName());
+        assertEquals("FEMALE", result.get().getGender());
+        verify(patientRepository, times(1)).findById(1L);
+        verify(patientRepository, times(1)).save(patient); // verify original patient object was mutated and saved
+    }
+
+    @Test
+    void updatePatient_shouldReturnEmpty_whenNotFound() {
+        Patient updatedDetails = new Patient(null, "Jane", "Doe", null, null, null, null, null);
+        when(patientRepository.findById(1L)).thenReturn(Optional.empty());
+        Optional<Patient> result = patientService.updatePatient(1L, updatedDetails);
+        assertFalse(result.isPresent());
+        verify(patientRepository, times(1)).findById(1L);
+        verify(patientRepository, never()).save(any(Patient.class));
+    }
+
+    @Test
+    void deletePatient_shouldReturnTrue_whenDeleted() {
+        when(patientRepository.existsById(1L)).thenReturn(true);
+        doNothing().when(patientRepository).deleteById(1L);
+        boolean deleted = patientService.deletePatient(1L);
+        assertTrue(deleted);
+        verify(patientRepository, times(1)).existsById(1L);
+        verify(patientRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void deletePatient_shouldReturnFalse_whenNotFound() {
+        when(patientRepository.existsById(1L)).thenReturn(false);
+        boolean deleted = patientService.deletePatient(1L);
+        assertFalse(deleted);
+        verify(patientRepository, times(1)).existsById(1L);
+        verify(patientRepository, never()).deleteById(1L);
+    }
+}


### PR DESCRIPTION
"Building domain entities"

## Summary by Sourcery

Initialize the medical domain by adding persistent entities (Doctor, User, Appointment, HistoryRecord), refactor the project into a patients-service microservice backed by Oracle, and implement a Patient REST API with full CRUD support and accompanying tests.

New Features:
- Introduce core JPA entities for Doctor, User, Appointment, and HistoryRecord with basic fields and lifecycle methods
- Implement a new Patient microservice with JPA model, repository, service, and REST controller to support CRUD operations

Enhancements:
- Enforce validation and trimming logic in HistoryRecord and add summary methods
- Rename and refactor project from generic API to patients-service, update package structure and main application class

Build:
- Switch default app image to Java 17, update Maven compiler settings and add Jakarta Persistence and Oracle JDBC dependencies
- Migrate Docker Compose from PostgreSQL to Oracle XE and provide a Dockerfile template for the patients service

Tests:
- Add unit tests for PatientController and PatientService to cover CRUD scenarios